### PR TITLE
Add persistent wallet connection to the dApp

### DIFF
--- a/harvest-flow/frontend/src/components/ConnectWalletButton.tsx
+++ b/harvest-flow/frontend/src/components/ConnectWalletButton.tsx
@@ -1,23 +1,20 @@
 import React from "react";
-import { AppContext } from "@src/main";
-import { useContext } from "react";
 import { WalletMode } from "@paima/providers";
 import type { LoginInfo } from "@paima/sdk/mw-core";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
-import type MainController from "@src/MainController";
 import { middleEllipsis } from "@src/utils";
 import { Page } from "@src/MainController";
+import { useSession } from "@src/utils/useSession";
 
 const ConnectWalletButton: React.FC = () => {
-  const mainController: MainController = useContext(AppContext);
-  const [userAddress, setUserAddress] = React.useState<string | null>(
-    mainController.userAddress,
-  );
+  const { userSession, initializeSession } = useSession();
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
 
+  // TODO: if you want the user to pick the wallet, see `getWalletOptions`
+  // https://docs.paimastudios.com/home/multichain-support/wallet-layer/introduction
   const loginInfo: LoginInfo = {
     mode: WalletMode.EvmInjected,
     preferBatchedMode: false,
@@ -25,7 +22,7 @@ const ConnectWalletButton: React.FC = () => {
 
   return (
     <div>
-      {mainController.isWalletConnected() && userAddress ? (
+      {userSession != null ? (
         <div
           className="text-heading5 desktop:text-header font-medium text-black uppercase p-4 hover:cursor-pointer"
           onClick={() => {
@@ -33,14 +30,12 @@ const ConnectWalletButton: React.FC = () => {
           }}
         >
           {" "}
-          {middleEllipsis(userAddress)}
+          {middleEllipsis(userSession.walletAddress)}
         </div>
       ) : (
         <button
           onClick={() => {
-            mainController.connectWallet(loginInfo, i18n.language).then((result) => {
-              setUserAddress(result);
-            });
+            void initializeSession(loginInfo, i18n.language);
           }}
           className="text-heading5 desktop:text-header font-medium text-black uppercase p-4 hover:cursor-pointer"
         >

--- a/harvest-flow/frontend/src/components/MobileConnectWalletButton.tsx
+++ b/harvest-flow/frontend/src/components/MobileConnectWalletButton.tsx
@@ -1,34 +1,27 @@
 import React from "react";
-import { AppContext } from "@src/main";
-import { useContext } from "react";
 import { WalletMode } from "@paima/providers";
 import type { LoginInfo } from "@paima/sdk/mw-core";
 import { useTranslation } from "react-i18next";
 
-import type MainController from "@src/MainController";
+import { useSession } from "@src/utils/useSession";
 
 const MobileConnectWalletButton: React.FC = () => {
-  const mainController: MainController = useContext(AppContext);
-  const [userAddress, setUserAddress] = React.useState<string | null>(
-    mainController.userAddress,
-  );
+  const { isInitialized, initializeSession } = useSession();
   const { t, i18n } = useTranslation();
 
+  // TODO: if you want the user to pick the wallet, see `getWalletOptions`
+  // https://docs.paimastudios.com/home/multichain-support/wallet-layer/introduction
   const loginInfo: LoginInfo = {
     mode: WalletMode.EvmInjected,
     preferBatchedMode: false,
   };
 
-  if (mainController.isWalletConnected() && userAddress) return null;
+  if (isInitialized) return null;
 
   return (
     <button
       onClick={() => {
-        mainController
-          .connectWallet(loginInfo, i18n.language)
-          .then((result) => {
-            setUserAddress(result);
-          });
+        void initializeSession(loginInfo, i18n.language)
       }}
       className="absolute left-[10vw] right-[10vw] top-16 w-[80vw] flex items-center justify-center uppercase text-bodySmaller_13_15 bg-white px-4 py-[14px] header-connect-wallet-button font-medium desktop:hidden"
     >

--- a/harvest-flow/frontend/src/pages/ProtectedRoute.tsx
+++ b/harvest-flow/frontend/src/pages/ProtectedRoute.tsx
@@ -1,12 +1,15 @@
-import React, { useContext } from "react";
-import MainController, { Page } from "@src/MainController";
+import React from "react";
+import { Page } from "@src/MainController";
 import { Navigate, Outlet } from "react-router-dom";
-import { AppContext } from "@src/main";
+import { useSession } from "@src/utils/useSession";
+import Layout from "@src/layouts/Layout";
 
 const ProtectedRoute: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const mainController: MainController = useContext(AppContext);
+  const { isInitializing, isInitialized } = useSession();
 
-  if (!mainController.isWalletConnected()) {
+  // TODO: should maybe show some kind of "connecting to wallet" message on the page
+  if (isInitializing) return <Layout enableIntroAnimation />
+  if (!isInitialized) {
     return <Navigate to={Page.Homepage} />;
   }
 

--- a/harvest-flow/frontend/src/utils/useSession.ts
+++ b/harvest-flow/frontend/src/utils/useSession.ts
@@ -1,0 +1,57 @@
+import React, { useContext, useEffect } from 'react';
+import { AppContext } from "@src/main";
+import type MainController from "@src/MainController";
+import type { LoginInfo, Wallet } from '@paima/sdk/mw-core';
+
+export const useSession = () => {
+  const controller: MainController = useContext(AppContext);
+  const [isConnectingWallet, setIsConnectingWallet] = React.useState<boolean>(true);
+  const [connectedWallet, setConnectedWallet] = React.useState<Wallet | null>(controller.connectedWallet);
+  const [connectWalletError, setConnectWalletError] = React.useState<string | null>(controller.connectWalletError);
+
+  if (!controller) {
+    throw new Error('useSession must be used within AppContext.Provider');
+  }
+
+  useEffect(() => {
+    setIsConnectingWallet(true);
+    const tryReconnect = async () => {
+      try {
+        if (controller.connectedWallet == null) {
+          await controller.tryReconnect();
+          setConnectedWallet(controller.connectedWallet);
+          setConnectWalletError(controller.connectWalletError);
+        }
+      } finally {
+        setIsConnectingWallet(false);
+      }
+    }
+    void tryReconnect();
+  }, [controller]);
+
+  const initializeSession = React.useCallback(async (loginInfo: LoginInfo, locale?: string) => {
+    try {
+      setIsConnectingWallet(true);
+      await controller.connectWallet(loginInfo, locale);
+      setConnectedWallet(controller.connectedWallet);
+      setConnectWalletError(controller.connectWalletError);
+    } finally {
+      setIsConnectingWallet(false);
+    }
+  }, [controller]);
+
+  const disconnectSession = React.useCallback(() => {
+    controller.disconnect();
+    setConnectedWallet(null);
+    setConnectWalletError(null);
+  }, [controller]);
+
+  return {
+    userSession: connectedWallet,
+    isInitialized: connectedWallet != null,
+    initializationError: connectWalletError,
+    isInitializing: isConnectingWallet,
+    initializeSession: initializeSession,
+    disconnectSession,
+  };
+};


### PR DESCRIPTION
This makes the Paima wallet connection persistent even when refreshing the page

I didn't implement the `disconnect` button, but I added the function for it so the UI can be implemented by somebody else